### PR TITLE
Add language selection feature for transcriptions

### DIFF
--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -12,7 +12,8 @@ import {
   TableCell,
   TableContainer,
   TableHead,
-  TableRow
+  TableRow,
+  Tooltip
 } from '@mui/material';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -20,6 +21,21 @@ import { useSession, getSession } from 'next-auth/react';
 import { GetServerSideProps } from 'next';
 import api from '../src/services/api';
 import AddIcon from '@mui/icons-material/Add';
+
+// Language map for display purposes
+const LANGUAGE_MAP: Record<string, string> = {
+  'en': 'English',
+  'es': 'Spanish',
+  'fr': 'French',
+  'de': 'German',
+  'it': 'Italian',
+  'pt': 'Portuguese',
+  'ru': 'Russian',
+  'ja': 'Japanese',
+  'zh': 'Chinese',
+  'ko': 'Korean',
+  'ar': 'Arabic',
+};
 
 // Define types for file metadata
 interface FileMetadata {
@@ -29,6 +45,7 @@ interface FileMetadata {
   duration_seconds: number;
   upload_date: string;
   status: 'pending' | 'processing' | 'completed' | 'failed';
+  language?: string;
 }
 
 const Dashboard: React.FC = () => {
@@ -90,6 +107,12 @@ const Dashboard: React.FC = () => {
     });
   };
 
+  // Get language name from code
+  const getLanguageName = (code?: string): string => {
+    if (!code) return 'English (default)';
+    return LANGUAGE_MAP[code] || code;
+  };
+
   return (
     <>
       <Head>
@@ -145,6 +168,7 @@ const Dashboard: React.FC = () => {
                     <TableCell>Filename</TableCell>
                     <TableCell>Size</TableCell>
                     <TableCell>Duration</TableCell>
+                    <TableCell>Language</TableCell>
                     <TableCell>Uploaded</TableCell>
                     <TableCell>Status</TableCell>
                     <TableCell align="right">Actions</TableCell>
@@ -156,6 +180,7 @@ const Dashboard: React.FC = () => {
                       <TableCell>{file.filename}</TableCell>
                       <TableCell>{formatFileSize(file.size)}</TableCell>
                       <TableCell>{formatDuration(file.duration_seconds)}</TableCell>
+                      <TableCell>{getLanguageName(file.language)}</TableCell>
                       <TableCell>{formatDate(file.upload_date)}</TableCell>
                       <TableCell>
                         <Box

--- a/frontend/pages/transcribe.tsx
+++ b/frontend/pages/transcribe.tsx
@@ -8,7 +8,8 @@ import {
   LinearProgress,
   Alert,
   TextField,
-  IconButton
+  IconButton,
+  Divider
 } from '@mui/material';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -17,6 +18,7 @@ import { GetServerSideProps } from 'next';
 import api from '../src/services/api';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { LanguageSelector } from '../src/components/transcription';
 
 const TranscribePage: React.FC = () => {
   const router = useRouter();
@@ -25,6 +27,7 @@ const TranscribePage: React.FC = () => {
   const [uploading, setUploading] = useState<boolean>(false);
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
+  const [selectedLanguage, setSelectedLanguage] = useState<string>('en');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -54,6 +57,7 @@ const TranscribePage: React.FC = () => {
       // Create form data
       const formData = new FormData();
       formData.append('file', selectedFile);
+      formData.append('language', selectedLanguage);
       
       // Mock progress updates (since we don't have real progress events)
       const progressInterval = setInterval(() => {
@@ -86,6 +90,10 @@ const TranscribePage: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.click();
     }
+  };
+
+  const handleLanguageChange = (language: string) => {
+    setSelectedLanguage(language);
   };
 
   return (
@@ -156,8 +164,16 @@ const TranscribePage: React.FC = () => {
               )}
             </Box>
             
+            <Divider sx={{ my: 3 }} />
+            
+            <LanguageSelector 
+              selectedLanguage={selectedLanguage}
+              onChange={handleLanguageChange}
+              disabled={uploading}
+            />
+            
             {uploading && (
-              <Box sx={{ mb: 3 }}>
+              <Box sx={{ mb: 3, mt: 3 }}>
                 <LinearProgress 
                   variant="determinate" 
                   value={uploadProgress} 
@@ -177,6 +193,7 @@ const TranscribePage: React.FC = () => {
               disabled={!selectedFile || uploading}
               onClick={handleUpload}
               startIcon={<CloudUploadIcon />}
+              sx={{ mt: 2 }}
             >
               {uploading ? 'Uploading...' : 'Upload and Transcribe'}
             </Button>

--- a/frontend/src/components/transcription/LanguageSelector.tsx
+++ b/frontend/src/components/transcription/LanguageSelector.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { 
+  FormControl, 
+  InputLabel, 
+  Select, 
+  MenuItem, 
+  SelectChangeEvent,
+  FormHelperText
+} from '@mui/material';
+
+// Define available languages for transcription
+const AVAILABLE_LANGUAGES = [
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'ar', name: 'Arabic' },
+];
+
+interface LanguageSelectorProps {
+  selectedLanguage: string;
+  onChange: (language: string) => void;
+  disabled?: boolean;
+}
+
+const LanguageSelector: React.FC<LanguageSelectorProps> = ({
+  selectedLanguage,
+  onChange,
+  disabled = false
+}) => {
+  const handleChange = (event: SelectChangeEvent) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <FormControl fullWidth margin="normal" disabled={disabled}>
+      <InputLabel id="transcription-language-label">Transcription Language</InputLabel>
+      <Select
+        labelId="transcription-language-label"
+        id="transcription-language"
+        value={selectedLanguage}
+        label="Transcription Language"
+        onChange={handleChange}
+      >
+        {AVAILABLE_LANGUAGES.map((language) => (
+          <MenuItem key={language.code} value={language.code}>
+            {language.name}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>
+        Select the primary language spoken in your audio
+      </FormHelperText>
+    </FormControl>
+  );
+};
+
+export default LanguageSelector; 

--- a/frontend/src/components/transcription/index.ts
+++ b/frontend/src/components/transcription/index.ts
@@ -1,0 +1,1 @@
+export { default as LanguageSelector } from './LanguageSelector'; 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -40,6 +40,7 @@ interface FileMetadata {
   duration_seconds: number;
   upload_date: string;
   status: 'pending' | 'processing' | 'completed' | 'failed';
+  language?: string;
 }
 
 interface TranscriptionData {
@@ -49,6 +50,7 @@ interface TranscriptionData {
   timestamps: Record<string, string>;
   created_at: string;
   updated_at: string;
+  language: string;
 }
 
 // Add a request interceptor to include authentication token
@@ -138,8 +140,8 @@ export const api = {
   
   // Transcription endpoints
   transcriptions: {
-    create: (fileId: string): Promise<TranscriptionData> => 
-      apiRequest('post', '/transcriptions', { file_id: fileId }),
+    create: (fileId: string, language: string = 'en'): Promise<TranscriptionData> => 
+      apiRequest('post', '/transcriptions', { file_id: fileId, language }),
     getById: (id: string): Promise<TranscriptionData> => 
       apiRequest('get', `/transcriptions/${id}`),
     getAll: (): Promise<TranscriptionData[]> => 


### PR DESCRIPTION
This PR adds language selection capabilities to the transcription feature, allowing users to specify the language of their audio files for more accurate transcription results.

Changes:
- Created reusable LanguageSelector component with 11 supported languages
- Updated transcribe page UI to include language selection
- Modified API service to pass language parameter to backend
- Enhanced dashboard to display the selected language for each transcription

Testing:
1. Navigate to the transcribe page
2. Verify language selector shows all options and defaults to English
3. Upload an audio file with a non-English language selected
4. Confirm the language is properly displayed on the dashboard